### PR TITLE
fix: exclude non-strong references from HPROF leak paths

### DIFF
--- a/tests/test_ai_context.py
+++ b/tests/test_ai_context.py
@@ -331,10 +331,15 @@ class EvidenceContextTests(unittest.TestCase):
         context = build_ai_context(root, intent="quick-triage")
         ledger = context["evidence"]["accounting_ledger"]
         rows = {row["name"]: row for row in ledger["rows"]}
+        meminfo = next(
+            artifact
+            for artifact in context["evidence"]["artifacts"]
+            if artifact["artifact_type"] == "meminfo" and artifact["status"] == "ok"
+        )
 
         self.assertEqual("available", ledger["status"])
         self.assertEqual(
-            "artifact:meminfo:6578c50e4ca4",
+            meminfo["artifact_id"],
             ledger["source_artifacts"]["meminfo"],
         )
         self.assertEqual(19, len(ledger["rows"]))

--- a/tests/test_legacy_parsers.py
+++ b/tests/test_legacy_parsers.py
@@ -15,6 +15,71 @@ from tools.memory_analyzer import MemoryAnalyzer
 
 
 class HprofParserRegressionTests(unittest.TestCase):
+    def test_gc_root_path_excludes_all_non_strong_reference_variants(self):
+        cases = (
+            ('java.lang.ref.WeakReference', None),
+            ('java.lang.ref.SoftReference', None),
+            ('java.lang.ref.PhantomReference', None),
+            ('sun.misc.Cleaner', None),
+            ('com.example.CustomCleanupReference', 'java.lang.ref.PhantomReference'),
+        )
+
+        for class_name, superclass_name in cases:
+            with self.subTest(class_name=class_name):
+                parser = HprofParser("unused.hprof")
+                wrapper_class_id = 20
+                parser.classes[wrapper_class_id] = {'name': class_name}
+                parser.instances[2] = {'class_id': wrapper_class_id}
+
+                if superclass_name:
+                    superclass_id = 21
+                    parser.classes[superclass_id] = {'name': superclass_name}
+                    parser.class_fields[wrapper_class_id] = {
+                        'super_class_id': superclass_id,
+                    }
+
+                parser.gc_roots[3] = {'type': parser.HEAP_TAG_ROOT_UNKNOWN}
+                parser.incoming_refs[1].add(2)
+                parser.incoming_refs[2].add(3)
+
+                self.assertIsNone(parser.find_path_to_gc_root(1))
+                self.assertEqual(
+                    [1, 2, 3],
+                    parser.find_path_to_gc_root(1, exclude_weak_refs=False),
+                )
+
+    def test_gc_root_path_keeps_ordinary_strong_reference_holders(self):
+        parser = HprofParser("unused.hprof")
+        parser.classes[20] = {'name': 'com.example.ReferenceCache'}
+        parser.instances[2] = {'class_id': 20}
+        parser.gc_roots[3] = {'type': parser.HEAP_TAG_ROOT_UNKNOWN}
+        parser.incoming_refs[1].add(2)
+        parser.incoming_refs[2].add(3)
+
+        self.assertEqual([1, 2, 3], parser.find_path_to_gc_root(1))
+
+    def test_markdown_export_formats_duplicate_bitmap_dimensions(self):
+        parser = HprofParser("unused.hprof")
+        parser.bitmap_info[1] = {
+            'width': 100,
+            'height': 200,
+            'estimated_size': 80_000,
+            'config': 'ARGB_8888',
+        }
+        parser.duplicate_bitmaps = [{
+            'size': (100, 200),
+            'count': 2,
+            'bitmap_ids': [1, 2],
+            'total_wasted': 80_000,
+        }]
+
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = Path(directory) / "report.md"
+            parser.export_markdown(str(report_path))
+            report = report_path.read_text(encoding="utf-8")
+
+        self.assertIn("**100x200**: 2 个相同尺寸", report)
+
     def test_retained_size_handles_a_chain_deeper_than_the_recursion_limit(self):
         parser = HprofParser("unused.hprof")
         depth = sys.getrecursionlimit() + 500

--- a/tools/dmabuf_parser.py
+++ b/tools/dmabuf_parser.py
@@ -303,7 +303,7 @@ def print_report(data: DmaBufData):
     print("\n" + "=" * 60)
 
 
-def to_json(data: DmaBufData) -> dict[str, object]:
+def to_json(data: DmaBufData) -> Dict[str, object]:
     """转换为 JSON 格式"""
     categories = {}
     for cat in data.get_categories():

--- a/tools/hprof_parser.py
+++ b/tools/hprof_parser.py
@@ -87,6 +87,18 @@ class HprofParser:
             'sun.security.jca.ServiceId',
         }
 
+        # References whose referents do not keep an object strongly reachable.
+        # Keep exact-name fallbacks for incomplete HPROF class hierarchies and
+        # also walk superclasses when checking instances below.
+        self.NON_STRONG_REFERENCE_CLASSES = {
+            'java.lang.ref.Reference',
+            'java.lang.ref.WeakReference',
+            'java.lang.ref.SoftReference',
+            'java.lang.ref.PhantomReference',
+            'sun.misc.Cleaner',
+            'jdk.internal.ref.Cleaner',
+        }
+
         # Interesting holder patterns (business objects)
         self.INTERESTING_PATTERNS = [
             'Activity', 'Fragment', 'View', 'Adapter', 'Holder',
@@ -788,8 +800,27 @@ class HprofParser:
 
         return refs
 
+    def _is_non_strong_reference_instance(self, obj_id):
+        """Return whether an instance belongs to a non-strong Reference hierarchy."""
+        class_id = self.instances.get(obj_id, {}).get('class_id')
+        visited = set()
+
+        while class_id and class_id not in visited:
+            visited.add(class_id)
+            class_info = self.classes.get(class_id, {})
+            if class_info.get('name', '') in self.NON_STRONG_REFERENCE_CLASSES:
+                return True
+
+            class_definition = self.class_fields.get(class_id, {})
+            class_id = class_definition.get(
+                'super_class_id',
+                class_info.get('super_class_id', 0),
+            )
+
+        return False
+
     def find_path_to_gc_root(self, obj_id, max_depth=50, exclude_weak_refs=True):
-        """Find shortest path from object to GC root (Phase 2.3)"""
+        """Find shortest strong-reference path from an object to a GC root."""
         if obj_id in self.gc_roots:
             return [obj_id]
 
@@ -813,13 +844,11 @@ class HprofParser:
             # Check incoming references
             for ref_id in self.incoming_refs.get(current_id, []):
                 if ref_id not in visited:
-                    # Skip weak/soft references if requested
-                    if exclude_weak_refs:
-                        ref_class_id = self.instances.get(ref_id, {}).get('class_id')
-                        if ref_class_id:
-                            class_name = self.classes.get(ref_class_id, {}).get('name', '')
-                            if 'WeakReference' in class_name or 'SoftReference' in class_name:
-                                continue
+                    # The historical option name is retained for compatibility,
+                    # but all Reference variants with non-strong referents must
+                    # be excluded from leak paths, including Phantom/Cleaner.
+                    if exclude_weak_refs and self._is_non_strong_reference_instance(ref_id):
+                        continue
                     queue.append((ref_id, path + [ref_id]))
 
         return None  # No path found
@@ -2956,7 +2985,8 @@ class HprofParser:
                     if hasattr(self, 'duplicate_bitmaps') and self.duplicate_bitmaps:
                         f.write("<details>\n<summary>重复 Bitmap 检测</summary>\n\n")
                         for dup in self.duplicate_bitmaps[:10]:
-                            f.write(f"- **{dup['dimensions']}**: {dup['count']} 个相同尺寸，浪费 {dup['total_wasted']/1024:.1f} KB\n")
+                            width, height = dup['size']
+                            f.write(f"- **{width}x{height}**: {dup['count']} 个相同尺寸，浪费 {dup['total_wasted']/1024:.1f} KB\n")
                         f.write("\n</details>\n\n")
                 else:
                     f.write("*未检测到 Bitmap 对象*\n\n")


### PR DESCRIPTION
## Summary

- Exclude WeakReference, SoftReference, PhantomReference, Cleaner, and their subclasses when resolving strong GC-root paths.
- Fix duplicate Bitmap Markdown export to format the stored `size` tuple instead of reading a missing `dimensions` key.
- Make the demo accounting-ledger assertion portable across checkout locations.

## Verification

- `bash scripts/verify.sh` (71 tests passed)
- Real compressed HPROF Markdown smoke test completed successfully
